### PR TITLE
Update preference_switch_layout.xml

### DIFF
--- a/library/src/main/res/layout/preference_switch_layout.xml
+++ b/library/src/main/res/layout/preference_switch_layout.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.SwitchCompat xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@android:id/checkbox"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:background="@null"
-    android:clickable="false"
-    android:focusable="false" />
+    android:layout_height="wrap_content" />


### PR DESCRIPTION
I have updated the layout file of the preference, so that the transition to pressed is animated (on Lollipop) and also users can drag the selector instead of clicking on it
